### PR TITLE
php_flag causes internal server error

### DIFF
--- a/data/themes/.htaccess
+++ b/data/themes/.htaccess
@@ -9,4 +9,11 @@
 
 Options -ExecCGI
 
-php_flag engine off
+# mod_php check for PHP 7.x
+<IfModule mod_php7.c>
+	php_flag engine off
+</IfModule>
+# mod_php check for PHP 8.x
+<IfModule mod_php.c>
+	php_flag engine off
+</IfModule>

--- a/data/trash/files/.htaccess
+++ b/data/trash/files/.htaccess
@@ -10,4 +10,11 @@ AddHandler default-handler
 
 Options -ExecCGI
 
-php_flag engine off
+# mod_php check for PHP 7.x
+<IfModule mod_php7.c>
+	php_flag engine off
+</IfModule>
+# mod_php check for PHP 8.x
+<IfModule mod_php.c>
+	php_flag engine off
+</IfModule>

--- a/files/.htaccess
+++ b/files/.htaccess
@@ -9,4 +9,11 @@ AddHandler default-handler
 
 Options -ExecCGI
 
-php_flag engine off
+# mod_php check for PHP 7.x
+<IfModule mod_php7.c>
+	php_flag engine off
+</IfModule>
+# mod_php check for PHP 8.x
+<IfModule mod_php.c>
+	php_flag engine off
+</IfModule>

--- a/images/.htaccess
+++ b/images/.htaccess
@@ -9,4 +9,11 @@
 
 Options -ExecCGI
 
-php_flag engine off
+# mod_php check for PHP 7.x
+<IfModule mod_php7.c>
+	php_flag engine off
+</IfModule>
+# mod_php check for PHP 8.x
+<IfModule mod_php.c>
+	php_flag engine off
+</IfModule>


### PR DESCRIPTION
Hi,

``php_flag`` causes internal server error If you PHP running via ``CGI`` or ``FastCGI``. it cannot configure through ``.htaccess`` on  ``CGI`` or ``FastCGI``
