### PR TITLE
Fix PHP error in "add modules to website" (fixes #133)

### DIFF
--- a/data/inc/modules_manage_addtosite.php
+++ b/data/inc/modules_manage_addtosite.php
@@ -66,6 +66,7 @@ if (isset($_POST['save'])) {
 		//Exclude the submit-button variable, and the modules that we don't want to show.
 		if ($variabletosplice != 'submit' && $display_order != 0) {
 			list($areaname, $modulename) = explode('|', $variabletosplice);
+			if ($areaname == "save" && $modulename == "" && $display_order == $lang['general']['save']) continue;
 			//Save the data.
 			fputs($file, "\n".'$space[\''.$areaname.'\'][\''.$modulename.'\'] = '.$display_order.';');
 		}


### PR DESCRIPTION
## Description
Fixed PHP error that occurs when pressing the save button in "add modules to website" settings.

## Problem
An unwanted `$space['save']['']` entry was being added to `data/settings/themes/default/moduleconf.php`, causing PHP errors.

## Solution
Added a check to exclude the submit button variable from being saved:
- Filters out entries where `$areaname == "save"`, `$modulename == ""`, and `$display_order` matches the localized save button text
- Uses `$lang['general']['save']` for proper internationalization support

## Related Issue
Fixes #133

## Testing
Tested with the "add modules to website" feature and confirmed the PHP error no longer occurs.