### PR TITLE
rc39 - possibility to point to other repo for updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 # and a tag convention that belong to one person's infrastructure. Kept beside a
 # checkout, handed to the build service separately, never in a release.
 image.yaml
+changes.md

--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,5 @@
 	"config": {
 		"sort-packages": true
 	},
-	"version": "5.0.0-rc38"
+	"version": "5.0.0-rc39"
 }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -40,6 +40,30 @@ return [
 This file must not be served over HTTP. `data/.htaccess` denies the whole
 directory on Apache; on nginx you have to say so yourself — see `NGINX.md`.
 
+### `update_source`
+
+Where the updater looks for releases. Unset means the Pluck repository, which is
+what a normal install wants.
+
+```php
+'update_source' => 'https://api.github.com/repos/yourname/pluck/releases/latest',
+```
+
+Only that shape is accepted — `api.github.com`, over TLS, a repository's latest
+release. Anything else falls back to the default rather than being fetched: a
+general "get it from wherever this says" is the same hole by a longer road.
+
+It is here rather than in Settings on purpose. An update source is code this
+install downloads and unpacks, so anything that can change it can run code here,
+and an administrator cannot do that today. Whoever can edit this file can already
+replace `src/` outright, so putting it here gives nothing away.
+
+The reason it exists: testing the updater otherwise means publishing a real
+release on the shared repository, and `/releases/latest` skips pre-releases — so
+a release candidate would have to go out as a normal release and become the
+headline release for everybody still on 4.7. Point a test install at a fork
+instead.
+
 ## Settings in storage
 
 | Key | Type | Default | Set where |

--- a/src/Admin/UpdateController.php
+++ b/src/Admin/UpdateController.php
@@ -175,7 +175,14 @@ final class UpdateController extends Controller
 
 	private function updates(): Updates
 	{
-		return new Updates($this->c->app->rootDir . '/data', $this->c->storage, $this->version());
+		// The source comes from config.php when it is set there — see
+		// Updates::api() for why it is a file and not a setting.
+		return new Updates(
+			$this->c->app->rootDir . '/data',
+			$this->c->storage,
+			$this->version(),
+			(string) $this->c->app->config->get('update_source', ''),
+		);
 	}
 
 	private function backups(): BackupManager

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -22,7 +22,7 @@ use Pluck\Support\Path;
  */
 final class Bootstrap
 {
-	public const VERSION = '5.0.0-rc38';
+	public const VERSION = '5.0.0-rc39';
 
 	private ?StorageDriver $storage = null;
 	private ?Session $session = null;

--- a/src/Update/Updates.php
+++ b/src/Update/Updates.php
@@ -46,7 +46,37 @@ final class Updates
 		private readonly string $dataDir,
 		private readonly StorageDriver $storage,
 		private readonly string $version = Bootstrap::VERSION,
+		private readonly ?string $source = null,
 	) {
+	}
+
+	/**
+	 * Where releases are looked for.
+	 *
+	 * Overridable from `config.php` — `'update_source' => '...'` — and from there
+	 * only. Deliberately not a setting: an update source is code this install will
+	 * download and unpack, so anything that can change it can run code here. An
+	 * administrator cannot do that today and should not gain it through a text
+	 * field. Whoever can edit config.php can already replace src/ outright, so
+	 * nothing is given away.
+	 *
+	 * It exists because testing the updater otherwise means publishing a real
+	 * release on the shared repository, which makes a release candidate the
+	 * headline release for everybody still on 4.7. Point a test install at a fork
+	 * instead.
+	 *
+	 * Only api.github.com over TLS: not a general "fetch from anywhere", which is
+	 * the same hole by a longer road.
+	 */
+	private function api(): string
+	{
+		if ($this->source === null || $this->source === '') {
+			return self::API;
+		}
+
+		return preg_match('~^https://api\\.github\\.com/repos/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/releases/latest$~', $this->source) === 1
+			? $this->source
+			: self::API;
 	}
 
 	// ---- checking -------------------------------------------------------
@@ -126,7 +156,7 @@ final class Updates
 
 	private function fetch(): ?Release
 	{
-		$json = $this->get(self::API);
+		$json = $this->get($this->api());
 		$data = json_decode($json, true);
 
 		if (!is_array($data) || !isset($data['tag_name'])) {

--- a/tests/UpdateTest.php
+++ b/tests/UpdateTest.php
@@ -25,6 +25,8 @@ final class UpdateTest extends TestCase
 {
 	public function run(): void
 	{
+		$this->group('where releases are looked for', fn () => $this->source());
+
 		$this->group('which version is newer', fn () => $this->versions());
 		$this->group('how often GitHub is asked', fn () => $this->caching());
 		$this->group('reaching the internet', fn () => $this->reaching());
@@ -190,5 +192,58 @@ final class UpdateTest extends TestCase
 		$storage->install();
 
 		return [new Updates($dir, $storage, '5.0.0'), $storage];
+	}
+
+	/**
+	 * The update source can be moved, from config.php and nowhere else.
+	 *
+	 * An update source is code this install downloads and unpacks, so anything
+	 * that can change it can run code here. An administrator cannot do that today
+	 * and must not gain it through a text field — whoever can edit config.php can
+	 * already replace src/ outright, so putting it there gives nothing away.
+	 *
+	 * It exists because testing the updater otherwise means publishing a real
+	 * release on the shared repository, and /releases/latest skips pre-releases:
+	 * a release candidate would have to go out as a normal release and become the
+	 * headline release for everybody still on 4.7.
+	 */
+	private function source(): void
+	{
+		$dir = $this->tempDir('pluck-update-source');
+		$storage = DriverFactory::make(DriverFactory::FLAT_FILE, $dir);
+		$storage->install();
+
+		$api = new \ReflectionMethod(Updates::class, 'api');
+		$api->setAccessible(true);
+
+		$default = 'https://api.github.com/repos/pluck-cms/pluck/releases/latest';
+
+		$this->assertSame(
+			$default,
+			$api->invoke(new Updates($dir, $storage, '5.0.0', '')),
+			'unset means the Pluck repository',
+		);
+
+		$fork = 'https://api.github.com/repos/somebody/pluck/releases/latest';
+		$this->assertSame(
+			$fork,
+			$api->invoke(new Updates($dir, $storage, '5.0.0', $fork)),
+			'a fork on the same host is accepted',
+		);
+
+		// Anything else falls back rather than being fetched. A general "get it
+		// from wherever this says" is the same hole by a longer road.
+		foreach ([
+			'https://evil.example/releases/latest',
+			'http://api.github.com/repos/a/b/releases/latest',
+			'https://api.github.com/repos/a/b/releases/latest?x=1',
+			'https://api.github.com.evil.example/repos/a/b/releases/latest',
+		] as $bad) {
+			$this->assertSame(
+				$default,
+				$api->invoke(new Updates($dir, $storage, '5.0.0', $bad)),
+				'refused and fell back: ' . $bad,
+			);
+		}
 	}
 }


### PR DESCRIPTION
Added the possibility to have another upstream repo for updates. 